### PR TITLE
revert reordering of ThunkAction type params

### DIFF
--- a/packages/redux-action-router/index.d.ts
+++ b/packages/redux-action-router/index.d.ts
@@ -17,7 +17,7 @@ export declare function actionHandler<
   TState = {},
   TExtraThunkArg = undefined,
   TBasicAction extends Action = AnyAction,
-  TAction extends TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown> = TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown>,
+  TAction extends TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction> = TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction>,
   TReturnType = unknown,
   TStore extends Store<TState, TBasicAction> & { dispatch: ThunkDispatch<TState, TExtraThunkArg, TBasicAction> } = 
     Store<TState, TBasicAction> & { dispatch: ThunkDispatch<TState, TExtraThunkArg, TBasicAction> }
@@ -30,7 +30,7 @@ export declare function dispatcher<
   TBasicAction extends Action,
 >(
   store: { dispatch: ThunkDispatch<TState, TExtraThunkArg, TBasicAction> },
-  match: (values: TValues) => TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown>,
+  match: (values: TValues) => TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction>,
   values: TValues,
   path: string
 ): void;
@@ -41,7 +41,7 @@ export interface RoutesMap<
   TBasicAction extends Action,
   TValues = any
 > {
-  [url: string]: (values: TValues) => TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown>;
+  [url: string]: (values: TValues) => TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction>;
 }
 
 export interface UrlSupport {
@@ -60,12 +60,12 @@ export interface ActionRouterOpts<
 > {
   dispatcher?: (
     store: TStore,
-    match: (values: TValues) => TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown>,
+    match: (values: TValues) => TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction>,
     values: TValues,
     path: string
   ) => void;
   actionHandler?: <
-    TAction extends TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown> = TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown>,
+    TAction extends TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction> = TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction>,
     TReturnType = unknown,
   >(store: TStore, next: (action: TAction) => TReturnType, action: TAction) => TReturnType;
   urlSupport?: (onChange: (url: string) => void) => UrlSupport;

--- a/packages/redux-action-router/package.json
+++ b/packages/redux-action-router/package.json
@@ -30,13 +30,13 @@
   "license": "MIT",
   "peerDependencies": {
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.0"
+    "redux-thunk-recursion-detect": "^1.1.1"
   },
   "devDependencies": {
     "jest": "^24.8.0",
     "redux": "^4.0.3",
     "redux-thunk": "^2.3.0",
-    "redux-thunk-recursion-detect": "^1.1.0",
+    "redux-thunk-recursion-detect": "1.1.1",
     "rollup": "^1.15.3"
   },
   "dependencies": {

--- a/packages/redux-action-router/package.json
+++ b/packages/redux-action-router/package.json
@@ -29,14 +29,14 @@
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "redux": "^4.0.1",
-    "redux-thunk-recursion-detect": "^1.1.1"
+    "redux": "^4.0.3",
+    "redux-thunk-recursion-detect": "^1.1.0"
   },
   "devDependencies": {
     "jest": "^24.8.0",
-    "redux": "^4.0.1",
+    "redux": "^4.0.3",
     "redux-thunk": "^2.3.0",
-    "redux-thunk-recursion-detect": "^1.1.1",
+    "redux-thunk-recursion-detect": "^1.1.0",
     "rollup": "^1.15.3"
   },
   "dependencies": {

--- a/packages/redux-action-router/yarn.lock
+++ b/packages/redux-action-router/yarn.lock
@@ -2615,19 +2615,19 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
-  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
+redux-thunk-recursion-detect@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
+  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
 
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
-redux@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+redux@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
+  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"

--- a/packages/redux-action-router/yarn.lock
+++ b/packages/redux-action-router/yarn.lock
@@ -2615,10 +2615,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
-  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
+redux-thunk-recursion-detect@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
+  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
 
 redux-thunk@^2.3.0:
   version "2.3.0"

--- a/packages/redux-awaitable-state/package.json
+++ b/packages/redux-awaitable-state/package.json
@@ -29,11 +29,11 @@
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "redux": "^4.0.1"
+    "redux": "^4.0.3"
   },
   "devDependencies": {
     "jest": "^24.8.0",
-    "redux": "^4.0.1",
+    "redux": "^4.0.3",
     "redux-thunk": "^2.3.0",
     "rollup": "^1.15.3"
   }

--- a/packages/redux-awaitable-state/yarn.lock
+++ b/packages/redux-awaitable-state/yarn.lock
@@ -2615,10 +2615,10 @@ redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
-redux@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+redux@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
+  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"

--- a/packages/redux-awaitable-thunk/index.d.ts
+++ b/packages/redux-awaitable-thunk/index.d.ts
@@ -8,7 +8,7 @@ export declare function awaitableThunk<
   TName extends string,
   TReturnTypeConstraint,
   TReturnType extends TReturnTypeConstraint,
->(name: TName, thunk: ThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnType>):
+>(name: TName, thunk: ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>):
   Required<AwaitableThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnTypeConstraint, TReturnType, TName, TName>>;
 
 export declare function after(name: string): Promise<void>;
@@ -25,7 +25,7 @@ export interface AwaitableThunkAction<
   TReturnType extends TReturnTypeConstraint = TReturnTypeConstraint,
   TAwaitableNames extends string = string,
   TName extends TAwaitableNames = TAwaitableNames,
-> extends ThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnType> {
+> extends ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction> {
   (
     dispatch: AwaitableThunkDispatch<TState, TExtraThunkArg, TBasicAction, TReturnTypeConstraint, TAwaitableNames>,
     getState: () => TState,

--- a/packages/redux-awaitable-thunk/index.d.ts
+++ b/packages/redux-awaitable-thunk/index.d.ts
@@ -9,7 +9,7 @@ export declare function awaitableThunk<
   TReturnTypeConstraint,
   TReturnType extends TReturnTypeConstraint,
 >(name: TName, thunk: ThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnType>):
-  Required<AwaitableThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnTypeConstraint, TReturnType, TName>>;
+  Required<AwaitableThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnTypeConstraint, TReturnType, TName, TName>>;
 
 export declare function after(name: string): Promise<void>;
 export declare function afterExactly(name: string, nCalls: number): Promise<void>;
@@ -23,14 +23,15 @@ export interface AwaitableThunkAction<
   TBasicAction extends Action,
   TReturnTypeConstraint = unknown,
   TReturnType extends TReturnTypeConstraint = TReturnTypeConstraint,
-  TAwaitableNames extends string = string
+  TAwaitableNames extends string = string,
+  TName extends TAwaitableNames = TAwaitableNames,
 > extends ThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnType> {
   (
     dispatch: AwaitableThunkDispatch<TState, TExtraThunkArg, TBasicAction, TReturnTypeConstraint, TAwaitableNames>,
     getState: () => TState,
     extraArgument: TExtraThunkArg
   ): TReturnType;
-  awaitableThunk?: TAwaitableNames;
+  awaitableThunk?: TName;
 }
 
 export interface AwaitableThunkDispatch<
@@ -40,8 +41,8 @@ export interface AwaitableThunkDispatch<
   TReturnTypeConstraint = unknown,
   TAwaitableNames extends string = string,
 > extends ThunkDispatch<TState, TExtraThunkArg, TBasicAction> {
-  <TReturnType extends TReturnTypeConstraint>(
-    thunkAction: AwaitableThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnTypeConstraint, TReturnType, TAwaitableNames>
+  <TReturnType extends TReturnTypeConstraint, TName extends TAwaitableNames>(
+    thunkAction: AwaitableThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnTypeConstraint, TReturnType, TAwaitableNames, TName>
   ): TReturnType;
   <A extends TBasicAction>(action: A): A;
 }

--- a/packages/redux-awaitable-thunk/package.json
+++ b/packages/redux-awaitable-thunk/package.json
@@ -27,16 +27,16 @@
     "await"
   ],
   "peerDependencies": {
-    "redux": "^4.0.1",
-    "redux-thunk-recursion-detect": "^1.1.1"
+    "redux": "^4.0.3",
+    "redux-thunk-recursion-detect": "^1.1.0"
   },
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
   "devDependencies": {
     "jest": "^24.8.0",
-    "redux": "^4.0.1",
+    "redux": "^4.0.3",
     "redux-thunk": "^2.3.0",
-    "redux-thunk-recursion-detect": "^1.1.1",
+    "redux-thunk-recursion-detect": "^1.1.0",
     "rollup": "^1.15.3"
   }
 }

--- a/packages/redux-awaitable-thunk/package.json
+++ b/packages/redux-awaitable-thunk/package.json
@@ -28,7 +28,7 @@
   ],
   "peerDependencies": {
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.0"
+    "redux-thunk-recursion-detect": "^1.1.1"
   },
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
@@ -36,7 +36,7 @@
     "jest": "^24.8.0",
     "redux": "^4.0.3",
     "redux-thunk": "^2.3.0",
-    "redux-thunk-recursion-detect": "^1.1.0",
+    "redux-thunk-recursion-detect": "1.1.1",
     "rollup": "^1.15.3"
   }
 }

--- a/packages/redux-awaitable-thunk/yarn.lock
+++ b/packages/redux-awaitable-thunk/yarn.lock
@@ -2611,19 +2611,19 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
-  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
+redux-thunk-recursion-detect@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
+  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
 
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
-redux@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+redux@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
+  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"

--- a/packages/redux-awaitable-thunk/yarn.lock
+++ b/packages/redux-awaitable-thunk/yarn.lock
@@ -2611,10 +2611,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
-  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
+redux-thunk-recursion-detect@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
+  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
 
 redux-thunk@^2.3.0:
   version "2.3.0"

--- a/packages/redux-socket.io-error-thunk/package.json
+++ b/packages/redux-socket.io-error-thunk/package.json
@@ -29,12 +29,12 @@
   "license": "MIT",
   "peerDependencies": {
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.1"
+    "redux-thunk-recursion-detect": "^1.1.0"
   },
   "devDependencies": {
     "jest": "^24.8.0",
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.1",
+    "redux-thunk-recursion-detect": "^1.1.0",
     "rollup": "^1.15.3"
   },
   "dependencies": {

--- a/packages/redux-socket.io-error-thunk/package.json
+++ b/packages/redux-socket.io-error-thunk/package.json
@@ -29,12 +29,12 @@
   "license": "MIT",
   "peerDependencies": {
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.0"
+    "redux-thunk-recursion-detect": "^1.1.1"
   },
   "devDependencies": {
     "jest": "^24.8.0",
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.0",
+    "redux-thunk-recursion-detect": "1.1.1",
     "rollup": "^1.15.3"
   },
   "dependencies": {

--- a/packages/redux-socket.io-error-thunk/yarn.lock
+++ b/packages/redux-socket.io-error-thunk/yarn.lock
@@ -2614,10 +2614,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
-  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
+redux-thunk-recursion-detect@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
+  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
 
 redux@^4.0.3:
   version "4.0.4"

--- a/packages/redux-socket.io-error-thunk/yarn.lock
+++ b/packages/redux-socket.io-error-thunk/yarn.lock
@@ -2614,15 +2614,15 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
-  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
+redux-thunk-recursion-detect@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
+  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
 
-redux@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+redux@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
+  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"

--- a/packages/redux-socket.io-message-thunk/index.d.ts
+++ b/packages/redux-socket.io-message-thunk/index.d.ts
@@ -10,7 +10,7 @@ export interface IoMessageHandlers<
   TExtraThunkArg,
   TBasicAction extends Action,
 > {
-  [type: string]: (message: any) => TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown>;
+  [type: string]: (message: any) => TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction>;
 }
 
 declare function createIoMessageMiddleware<

--- a/packages/redux-socket.io-message-thunk/package.json
+++ b/packages/redux-socket.io-message-thunk/package.json
@@ -28,13 +28,13 @@
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "redux-thunk-recursion-detect": "^1.1.1",
+    "redux-thunk-recursion-detect": "^1.1.0",
     "redux": "^4.0.3"
   },
   "devDependencies": {
     "jest": "^24.8.0",
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.1",
+    "redux-thunk-recursion-detect": "^1.1.0",
     "rollup": "^1.15.3"
   }
 }

--- a/packages/redux-socket.io-message-thunk/package.json
+++ b/packages/redux-socket.io-message-thunk/package.json
@@ -28,13 +28,13 @@
   "author": "ian.b.taylor@gmail.com",
   "license": "MIT",
   "peerDependencies": {
-    "redux-thunk-recursion-detect": "^1.1.0",
+    "redux-thunk-recursion-detect": "^1.1.1",
     "redux": "^4.0.3"
   },
   "devDependencies": {
     "jest": "^24.8.0",
     "redux": "^4.0.3",
-    "redux-thunk-recursion-detect": "^1.1.0",
+    "redux-thunk-recursion-detect": "1.1.0",
     "rollup": "^1.15.3"
   }
 }

--- a/packages/redux-socket.io-message-thunk/yarn.lock
+++ b/packages/redux-socket.io-message-thunk/yarn.lock
@@ -2611,10 +2611,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
-  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
+redux-thunk-recursion-detect@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
+  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
 
 redux@^4.0.3:
   version "4.0.3"

--- a/packages/redux-socket.io-message-thunk/yarn.lock
+++ b/packages/redux-socket.io-message-thunk/yarn.lock
@@ -2611,10 +2611,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
-  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
+redux-thunk-recursion-detect@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.0.tgz#b61c347d04dfb5c9acf5c3764691b305b321300c"
+  integrity sha512-uI5VltNx4Rkr/2LrfN8vFLW7nRuaeeAM+S+gCiqbW7uYEvlJiKWY2fMMyes9Rh7FbaC6NxA3caPGNIRkJjW1lw==
 
 redux@^4.0.3:
   version "4.0.3"

--- a/packages/redux-thunk-error-handler/index.d.ts
+++ b/packages/redux-thunk-error-handler/index.d.ts
@@ -5,18 +5,18 @@ declare function createThunkErrorCatchMiddleware<
   TState = {},
   TExtraThunkArg = undefined,
   TBasicAction extends Action = AnyAction,
->(config: { onError(error: unknown): TBasicAction | ThunkAction<TState, TExtraThunkArg, TBasicAction, unknown> | void }): Middleware<
+>(config: { onError(error: unknown): TBasicAction | ThunkAction<unknown, TState, TExtraThunkArg, TBasicAction> | void }): Middleware<
   {},
   TState,
   ThunkDispatch<TState, TExtraThunkArg, TBasicAction>
 >;
 
 export declare function forceHandleError<
+  TReturnType,
   TState,
   TExtraThunkArg,
   TBasicAction extends Action,
-  TReturnType 
->(thunkFn: ThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnType>): ThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnType>; 
+>(thunkFn: ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>): ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>; 
 
 export declare const handleErrorsSymbol: symbol;
 export default createThunkErrorCatchMiddleware;

--- a/packages/redux-thunk-error-handler/package.json
+++ b/packages/redux-thunk-error-handler/package.json
@@ -45,6 +45,6 @@
     "rollup": "^1.15.3"
   },
   "dependencies": {
-    "redux-thunk-recursion-detect": "^1.1.0"
+    "redux-thunk-recursion-detect": "1.1.1"
   }
 }

--- a/packages/redux-thunk-error-handler/package.json
+++ b/packages/redux-thunk-error-handler/package.json
@@ -45,6 +45,6 @@
     "rollup": "^1.15.3"
   },
   "dependencies": {
-    "redux-thunk-recursion-detect": "^1.1.1"
+    "redux-thunk-recursion-detect": "^1.1.0"
   }
 }

--- a/packages/redux-thunk-error-handler/yarn.lock
+++ b/packages/redux-thunk-error-handler/yarn.lock
@@ -2828,10 +2828,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
-  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
+redux-thunk-recursion-detect@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
+  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
 
 redux@^4.0.3:
   version "4.0.3"

--- a/packages/redux-thunk-error-handler/yarn.lock
+++ b/packages/redux-thunk-error-handler/yarn.lock
@@ -2828,10 +2828,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux-thunk-recursion-detect@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.1.tgz#7f1b13d0442bc287f37bb46e2d6943dab13d0f00"
-  integrity sha512-s50xHim5GJJQ1s5ZFXx43ZxP1L7041Fa/ZkDn+MKvmsWd0oP7wCjQPjX3LUu6fUrlyKdY1hS60cQcMV53nvC3g==
+redux-thunk-recursion-detect@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk-recursion-detect/-/redux-thunk-recursion-detect-1.1.2.tgz#4770e126333de9a2481bc37b84a73918b83eb021"
+  integrity sha512-wHfTpTA30Ow1yirIDee3uCaexpE268YTinPqMqhkEey07NiPhqhwADI82EbbMly1JgCQrr/kjOCgu8bOW5z0wA==
 
 redux@^4.0.3:
   version "4.0.3"

--- a/packages/redux-thunk-recursion-detect/index.d.ts
+++ b/packages/redux-thunk-recursion-detect/index.d.ts
@@ -16,8 +16,6 @@ import {
  * @template TExtraThunkArg The extra argument passed to the inner function of
  * thunks (if specified when setting up the Thunk middleware)
  * @template TBasicAction The (non-thunk) actions that can be dispatched.
- * @template TReturnTypeConstraint Gives the ability to restrain the possible
- * thunk return types
  */
 export interface ThunkDispatch<
   TState,
@@ -42,8 +40,6 @@ export interface ThunkDispatch<
  * @template TExtraThunkARg Optional extra argument passed to the inner function
  * (if specified when setting up the Thunk middleware)
  * @template TBasicAction The (non-thunk) actions that can be dispatched.
- * @template TReturnTypeConstraint Gives the ability to restrain the possible
- * thunk return types
  */
 export type ThunkAction<
   TReturnType,

--- a/packages/redux-thunk-recursion-detect/index.d.ts
+++ b/packages/redux-thunk-recursion-detect/index.d.ts
@@ -25,7 +25,7 @@ export interface ThunkDispatch<
   TBasicAction extends Action,
 > {
   <TReturnType>(
-    thunkAction: ThunkAction<TState, TExtraThunkArg, TBasicAction, TReturnType>
+    thunkAction: ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>
   ): TReturnType;
   <A extends TBasicAction>(action: A): A;
 }
@@ -46,10 +46,10 @@ export interface ThunkDispatch<
  * thunk return types
  */
 export type ThunkAction<
+  TReturnType,
   TState,
   TExtraThunkArg,
-  TBasicAction extends Action,
-  TReturnType
+  TBasicAction extends Action
 > = (
   dispatch: ThunkDispatch<TState, TExtraThunkArg, TBasicAction>,
   getState: () => TState,


### PR DESCRIPTION
I goofed and reordered the type parameters on `redux-thunk`'s `ThunkAction` type, so this reverts that.